### PR TITLE
Tiny enhancements

### DIFF
--- a/concrete5-upgrade.sh
+++ b/concrete5-upgrade.sh
@@ -33,8 +33,8 @@ DEV_DB_DATABASE=""
 SITE_NAME="Concrete5"
 WHERE_IS_CONCRETE5="/var/www/vhosts/concrete5"
 
-C5_Version="8.5.1"
-CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/download_file/-/view/109615/8497/"
+C5_Version="8.5.2"
+CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/download_file/-/view/111592/"
 
 # Concrete 5 Download Links
 #   '5.7.5.13'=>'http://www.concrete5.org/download_file/-/view/93075/8497/',
@@ -57,6 +57,7 @@ CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/download_file/-/view/10961
 #    '8.4.5'=>'https://www.concrete5.org/download_file/-/view/108839/8497/'
 #    '8.5.0'=>'https://www.concrete5.org/download_file/-/view/109116/8497/'
 #    '8.5.1'=>'https://www.concrete5.org/download_file/-/view/109615/8497/'
+#    '8.5.2'=>'https://www.concrete5.org/download_file/-/view/111592/'
 
 # Backup Variables
 WHERE_TO_SAVE="/var/www/vhosts/backups"

--- a/concrete5-upgrade.sh
+++ b/concrete5-upgrade.sh
@@ -29,17 +29,17 @@ DEV_DB_USERNAME=""
 DEV_DB_PASSWORD=""
 DEV_DB_DATABASE=""
 
-# Backup Variables
-WHERE_TO_SAVE="/var/www/vhosts/backups"
-FILE_NAME="${C5_Version}-upgrade"
-USER_PERMISSIONS="apache:apache"
-
 # Concrete5 Variables
 SITE_NAME="Concrete5"
 WHERE_IS_CONCRETE5="/var/www/vhosts/concrete5"
 
 C5_Version="8.5.2"
 CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/latest.zip"
+
+# Backup Variables
+WHERE_TO_SAVE="/var/www/vhosts/backups"
+FILE_NAME="${C5_Version}-upgrade"
+USER_PERMISSIONS="apache:apache"
 
 # Concrete 5 Download Links
 #    '8.5.2'=>'https://www.concrete5.org/download_file/-/view/111592/'

--- a/concrete5-upgrade.sh
+++ b/concrete5-upgrade.sh
@@ -39,30 +39,30 @@ SITE_NAME="Concrete5"
 WHERE_IS_CONCRETE5="/var/www/vhosts/concrete5"
 
 C5_Version="8.5.2"
-CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/download_file/-/view/111592/"
+CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/latest.zip"
 
 # Concrete 5 Download Links
-#   '5.7.5.13'=>'http://www.concrete5.org/download_file/-/view/93075/8497/',
-#   '8.0.0'=>'http://www.concrete5.org/download_file/-/view/92663/8497/',
-#   '8.0.1'=>'http://www.concrete5.org/download_file/-/view/92834/8497/',
-#   '8.0.2'=>'http://www.concrete5.org/download_file/-/view/92910/8497/',
-#   '8.0.3'=>'http://www.concrete5.org/download_file/-/view/93074/8497/',
-#   '8.1.0'=>'http://www.concrete5.org/download_file/-/view/93797/8497/',
-#   '8.2.0'=>'http://www.concrete5.org/download_file/-/view/96765/8497/',
-#    '8.2.1'=>'http://www.concrete5.org/download_file/-/view/96959/8497/',
-#    '8.3.0'=>'http://www.concrete5.org/download_file/-/view/99806/8497/',
-#    '8.3.1'=>'http://www.concrete5.org/download_file/-/view/99963/8497/',
-#    '8.3.2'=>'http://www.concrete5.org/download_file/-/view/100595/8497/',
-#    '8.4.0'=>'http://www.concrete5.org/download_file/-/view/104344/',
-#    '8.4.0'=>'http://www.concrete5.org/download_file/-/view/104344/'
-#    '8.4.1'=>'http://www.concrete5.org/download_file/-/view/105022/'
-#    '8.4.2'=>'http://www.concrete5.org/download_file/-/view/105477/'
-#    '8.4.3'=>'http://www.concrete5.org/download_file/-/view/106698/'
-#    '8.4.4'=>'https://www.concrete5.org/download_file/-/view/108181/8497/'
-#    '8.4.5'=>'https://www.concrete5.org/download_file/-/view/108839/8497/'
-#    '8.5.0'=>'https://www.concrete5.org/download_file/-/view/109116/8497/'
-#    '8.5.1'=>'https://www.concrete5.org/download_file/-/view/109615/8497/'
 #    '8.5.2'=>'https://www.concrete5.org/download_file/-/view/111592/'
+#    '8.5.1'=>'https://www.concrete5.org/download_file/-/view/109615/8497/'
+#    '8.5.0'=>'https://www.concrete5.org/download_file/-/view/109116/8497/'
+#    '8.4.5'=>'https://www.concrete5.org/download_file/-/view/108839/8497/'
+#    '8.4.4'=>'https://www.concrete5.org/download_file/-/view/108181/8497/'
+#    '8.4.3'=>'http://www.concrete5.org/download_file/-/view/106698/'
+#    '8.4.2'=>'http://www.concrete5.org/download_file/-/view/105477/'
+#    '8.4.1'=>'http://www.concrete5.org/download_file/-/view/105022/'
+#    '8.4.0'=>'http://www.concrete5.org/download_file/-/view/104344/'
+#    '8.4.0'=>'http://www.concrete5.org/download_file/-/view/104344/',
+#    '8.3.2'=>'http://www.concrete5.org/download_file/-/view/100595/8497/',
+#    '8.3.1'=>'http://www.concrete5.org/download_file/-/view/99963/8497/',
+#    '8.3.0'=>'http://www.concrete5.org/download_file/-/view/99806/8497/',
+#    '8.2.1'=>'http://www.concrete5.org/download_file/-/view/96959/8497/',
+#    '8.2.0'=>'http://www.concrete5.org/download_file/-/view/96765/8497/',
+#    '8.1.0'=>'http://www.concrete5.org/download_file/-/view/93797/8497/',
+#    '8.0.3'=>'http://www.concrete5.org/download_file/-/view/93074/8497/',
+#    '8.0.2'=>'http://www.concrete5.org/download_file/-/view/92910/8497/',
+#    '8.0.1'=>'http://www.concrete5.org/download_file/-/view/92834/8497/',
+#    '8.0.0'=>'http://www.concrete5.org/download_file/-/view/92663/8497/',
+#    '5.7.5.13'=>'http://www.concrete5.org/download_file/-/view/93075/8497/',
 
 # ==============================
 #

--- a/concrete5-upgrade.sh
+++ b/concrete5-upgrade.sh
@@ -29,6 +29,11 @@ DEV_DB_USERNAME=""
 DEV_DB_PASSWORD=""
 DEV_DB_DATABASE=""
 
+# Backup Variables
+WHERE_TO_SAVE="/var/www/vhosts/backups"
+FILE_NAME="${C5_Version}-upgrade"
+USER_PERMISSIONS="apache:apache"
+
 # Concrete5 Variables
 SITE_NAME="Concrete5"
 WHERE_IS_CONCRETE5="/var/www/vhosts/concrete5"
@@ -58,12 +63,6 @@ CONCRETE5_PACKAGE_DOWNLOAD="https://www.concrete5.org/download_file/-/view/11159
 #    '8.5.0'=>'https://www.concrete5.org/download_file/-/view/109116/8497/'
 #    '8.5.1'=>'https://www.concrete5.org/download_file/-/view/109615/8497/'
 #    '8.5.2'=>'https://www.concrete5.org/download_file/-/view/111592/'
-
-# Backup Variables
-WHERE_TO_SAVE="/var/www/vhosts/backups"
-FILE_NAME="${C5_Version}-upgrade"
-USER_PERMISSIONS="apache:apache"
-
 
 # ==============================
 #


### PR DESCRIPTION
I have changed these from my (as a user) experiences.
IMO,
- Backup variables before the download links would be more convenient. There's a possibility to forget about this if it's under the long comments.
- We can use the `latest.zip` URL on the download link so that we can avoid updating the URL every time.
- Usually, we update to the latest version. So, the reverse order could be more convenient.