### PR TITLE
only do chown to generated overrides & doctorine folder

### DIFF
--- a/concrete5-upgrade.sh
+++ b/concrete5-upgrade.sh
@@ -912,7 +912,8 @@ do_upgrade() {
 
 update_file_permissions() {
     echo "c5 Upgrade: Updating file folder permissions"
-    sudo chown -R ${USER_PERMISSIONS} ${WHERE_IS_CONCRETE5}/application/config
+    sudo chown -R ${USER_PERMISSIONS} ${WHERE_IS_CONCRETE5}/application/config/doctrine
+    sudo chown -R ${USER_PERMISSIONS} ${WHERE_IS_CONCRETE5}/application/config/generated_overrides
     sudo chown -R ${USER_PERMISSIONS} ${WHERE_IS_CONCRETE5}/application/files
     sudo chown -R ${USER_PERMISSIONS} ${WHERE_IS_CONCRETE5}/application/languages
     sudo chown -R ${USER_PERMISSIONS} ${WHERE_IS_CONCRETE5}/concrete


### PR DESCRIPTION
@katzueno 
generated overrideとdoctrineだけchownコマンドが実行されるように修正しました。
確認お願いします。